### PR TITLE
use r2d2::Pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2390,6 +2390,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "r2d2"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
+dependencies = [
+ "log",
+ "parking_lot",
+ "scheduled-thread-pool",
+]
+
+[[package]]
+name = "r2d2_sqlite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a982edf65c129796dba72f8775b292ef482b40d035e827a9825b3bc07ccc5f2"
+dependencies = [
+ "r2d2",
+ "rusqlite",
+ "uuid",
+]
+
+[[package]]
 name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2693,6 +2715,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scheduled-thread-pool"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
+dependencies = [
+ "parking_lot",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2960,12 +2991,15 @@ name = "shared"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "r2d2",
+ "r2d2_sqlite",
  "reqwest",
  "rss",
  "rusqlite",
  "scraper",
  "serde",
  "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -3812,6 +3846,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 dependencies = [
  "getrandom 0.2.15",
+ "rand 0.8.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-
+resolver = "2"
 members = ["server", "shared", "news-gui/src-tauri"]

--- a/news-gui/src-tauri/src/core/mod.rs
+++ b/news-gui/src-tauri/src/core/mod.rs
@@ -1,28 +1,27 @@
 use std::{
     fs,
-    sync::{Mutex, MutexGuard, OnceLock},
+    sync::{Mutex, OnceLock},
 };
 
-use rusqlite::Connection;
 use shared::{
-    db::init_db,
+    db::{self, DbPool},
     rss_feeds::{FeedUrl, RssItem},
 };
 use tauri::AppHandle;
 
 pub struct ApplicationState {
-    pub db: OnceLock<Mutex<Connection>>,
+    pub db: OnceLock<DbPool>,
     pub feeds: Mutex<Vec<FeedUrl>>,
     pub items: Mutex<Vec<RssItem>>,
 }
 
 impl ApplicationState {
-    pub fn db(&self) -> MutexGuard<'_, Connection> {
-        self.db.get().unwrap().lock().unwrap()
+    pub fn db(&self) -> &DbPool {
+        self.db.get().unwrap()
     }
 }
 
-pub fn initialize_database(app_handle: &AppHandle) -> Result<Connection, rusqlite::Error> {
+pub fn initialize_database(app_handle: &AppHandle) -> db::Result<DbPool> {
     let app_dir = app_handle
         .path_resolver()
         .app_data_dir()
@@ -30,7 +29,7 @@ pub fn initialize_database(app_handle: &AppHandle) -> Result<Connection, rusqlit
     println!("App dir: {:?}", &app_dir);
     fs::create_dir_all(&app_dir).expect("Failed to create app data directory");
     let sqlite_path = app_dir.join("news.db");
-    let db = init_db(&sqlite_path)?;
+    let db = db::init(&sqlite_path)?;
 
     Ok(db)
 }

--- a/news-gui/src-tauri/src/rss/mod.rs
+++ b/news-gui/src-tauri/src/rss/mod.rs
@@ -1,11 +1,10 @@
 use anyhow::Result;
-use rusqlite::Connection;
 use shared::{
-    db::store_rss_items,
+    db::{store_rss_items, DbPool},
     rss_feeds::{add_feed_url, fetch_rss_from_feeds, get_all_rss_items, RssItem},
 };
 
-pub fn populate_rss_feeds(db: &Connection) {
+pub fn populate_rss_feeds(db: &DbPool) {
     let urls: Vec<(String, String)> = vec![
         ("https://feeds.bbci.co.uk/news/world/rss.xml".to_string(), "BBC World News".to_string()),
         ("https://www.nytimes.com/svc/collections/v1/publish/https://www.nytimes.com/section/world/rss.xml".to_string(), "New York Times World News".to_string()),
@@ -13,11 +12,11 @@ pub fn populate_rss_feeds(db: &Connection) {
     ];
 
     for (url, name) in urls {
-        add_feed_url(&db, &url, &name).expect("Failed to add feed URL");
+        add_feed_url(db, &url, &name).expect("Failed to add feed URL");
     }
 }
 
-pub async fn populate_rss_items(db: &Connection) -> Result<()> {
+pub async fn populate_rss_items(db: DbPool) -> Result<()> {
     let rss_map = fetch_rss_from_feeds(&db).await?;
 
     for (url, items) in rss_map {
@@ -28,18 +27,18 @@ pub async fn populate_rss_items(db: &Connection) -> Result<()> {
     Ok(())
 }
 
-pub async fn get_rss_items(db: &Connection) -> Result<Vec<RssItem>> {
+pub async fn get_rss_items(db: DbPool) -> Result<Vec<RssItem>> {
     let rss_items = get_all_rss_items(&db);
-    if let Ok(items) = rss_items {
-        if items.len() == 0 {
-            let _ = populate_rss_items(&db).await;
-            return get_all_rss_items(&db);
-        } else {
-            println!("Found {} items in the database", items.len());
-            return Ok(items);
-        }
-    } else {
-        let _ = populate_rss_items(&db).await;
+    let Ok(items) = rss_items else {
+        let _ = populate_rss_items(db.clone()).await;
         return get_all_rss_items(&db);
+    };
+
+    if items.is_empty() {
+        let _ = populate_rss_items(db.clone()).await;
+        get_all_rss_items(&db)
+    } else {
+        println!("Found {} items in the database", items.len());
+        Ok(items)
     }
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,7 +1,7 @@
-use std::{path::PathBuf, sync::Arc};
+use std::path::PathBuf;
 
 use shared::{
-    db::{init_db, store_news_item, store_rss_items},
+    db::{init, store_news_item, store_rss_items, DbPool},
     news::fetch_news_from_url,
     rss_feeds::{
         add_feed_url, clear_feed_urls, fetch_rss_from_feeds, filter_rss_items_by_source,
@@ -10,7 +10,7 @@ use shared::{
 };
 
 struct State {
-    db: Arc<rusqlite::Connection>,
+    db: DbPool,
 }
 
 async fn setup_rss_feeds(state: &State) {
@@ -22,22 +22,22 @@ async fn setup_rss_feeds(state: &State) {
         ("https://rss.gazeta.pl/pub/rss/najnowsze_wyborcza.xml".to_string(), "Gazeta Wyborcza".to_string()),
     ];
 
-    clear_feed_urls(&db).expect("Failed to clear feed URLs");
+    clear_feed_urls(db).expect("Failed to clear feed URLs");
 
     for (url, name) in urls {
-        add_feed_url(&db, &url, &name).expect("Failed to add feed URL");
+        add_feed_url(db, &url, &name).expect("Failed to add feed URL");
     }
 
-    let rss_map = fetch_rss_from_feeds(&db)
+    let rss_map = fetch_rss_from_feeds(db)
         .await
         .expect("Failed to fetch RSS feeds");
 
     for (url, items) in rss_map {
-        store_rss_items(&db, &items).expect("Failed to store RSS items");
+        store_rss_items(db, &items).expect("Failed to store RSS items");
         println!("Fetched {} items from {}", items.len(), url);
     }
 
-    let items = get_all_rss_items(&db).expect("Failed to get all RSS items");
+    let items = get_all_rss_items(db).expect("Failed to get all RSS items");
 
     for item in items.iter() {
         println!("{:?}, {}, {}", item.source, item.title, item.link);
@@ -52,7 +52,7 @@ async fn setup_rss_feeds(state: &State) {
 async fn main() {
     let db_path = PathBuf::from("news.db");
     let state = State {
-        db: Arc::new(init_db(&db_path).expect("Failed to initialize database")),
+        db: init(&db_path).expect("Failed to initialize database"),
     };
     setup_rss_feeds(&state).await;
 
@@ -62,7 +62,7 @@ async fn main() {
     if let Some(item) = bbc_items.get(2) {
         println!("{:?}", item);
 
-        let news = fetch_news_from_url(&state.db, &item.link, shared::news::NewsSource::BBC)
+        let news = fetch_news_from_url(state.db.clone(), &item.link, shared::news::NewsSource::BBC)
             .await
             .expect("Failed to fetch news from URL");
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use shared::{
-    db::{init, store_news_item, store_rss_items, DbPool},
+    db::{self, store_news_item, store_rss_items, DbPool},
     news::fetch_news_from_url,
     rss_feeds::{
         add_feed_url, clear_feed_urls, fetch_rss_from_feeds, filter_rss_items_by_source,
@@ -52,7 +52,7 @@ async fn setup_rss_feeds(state: &State) {
 async fn main() {
     let db_path = PathBuf::from("news.db");
     let state = State {
-        db: init(&db_path).expect("Failed to initialize database"),
+        db: db::init(&db_path).expect("Failed to initialize database"),
     };
     setup_rss_feeds(&state).await;
 

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -5,9 +5,12 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.86"
+r2d2 = "0.8.10"
+r2d2_sqlite = "0.24.0"
 reqwest = { version = "0.12.4", features = ["json", "blocking"] }
 rss = "2.0.8"
 rusqlite = { version = "0.31.0", features = ["bundled"] }
 scraper = "0.19.0"
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.117"
+thiserror = "1.0.61"

--- a/shared/src/db/mod.rs
+++ b/shared/src/db/mod.rs
@@ -1,15 +1,28 @@
-use std::path::PathBuf;
-
-use anyhow::Result;
+use r2d2_sqlite::SqliteConnectionManager;
 use rusqlite::params;
-use rusqlite::Connection;
+use std::path::Path;
 
 use crate::news::NewsItem;
 use crate::rss_feeds::get_all_rss_items;
 use crate::rss_feeds::RssItem;
 
-pub fn init_db(path: &PathBuf) -> Result<Connection, rusqlite::Error> {
-    let conn = Connection::open(path)?;
+pub type DbPool = r2d2::Pool<SqliteConnectionManager>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error(transparent)]
+    Pool(#[from] r2d2::Error),
+    #[error(transparent)]
+    Connection(#[from] rusqlite::Error),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+pub fn init(path: &Path) -> Result<DbPool> {
+    let manager = SqliteConnectionManager::file(path);
+    let pool = r2d2::Pool::new(manager).unwrap();
+    let conn = pool.get()?;
+
     conn.execute(
         "
         CREATE TABLE IF NOT EXISTS rss_items (
@@ -44,16 +57,16 @@ pub fn init_db(path: &PathBuf) -> Result<Connection, rusqlite::Error> {
         [],
     )?;
 
-    Ok(conn)
+    Ok(pool)
 }
 
-pub fn store_rss_items(conn: &Connection, items: &[RssItem]) -> Result<()> {
-    let existing_items = get_all_rss_items(conn)?;
+pub fn store_rss_items(db: &DbPool, items: &[RssItem]) -> anyhow::Result<()> {
+    let existing_items = get_all_rss_items(db)?;
     for item in items {
         if existing_items.iter().any(|i| i.link == item.link) {
             continue;
         }
-        conn.execute(
+        db.get()?.execute(
             "INSERT INTO rss_items (title, link, description, pub_date, source) VALUES (?1, ?2, ?3, ?4, ?5)",
             params![item.title, item.link, item.description, item.pub_date, item.source],
         )?;
@@ -62,8 +75,8 @@ pub fn store_rss_items(conn: &Connection, items: &[RssItem]) -> Result<()> {
     Ok(())
 }
 
-pub fn store_news_item(conn: &Connection, item: &NewsItem) -> Result<()> {
-    conn.execute(
+pub fn store_news_item(db: &DbPool, item: &NewsItem) -> Result<()> {
+    db.get()?.execute(
         "INSERT INTO news_items (title, author, body, url) VALUES (?1, ?2, ?3, ?4)",
         params![item.title, item.author, item.body, item.url],
     )?;


### PR DESCRIPTION
`rusqlite` is relatively low-level lib and it's `Connection` type doesn't implement `Send` nor `Sync`. Sure, you could wrap the `Connection` in `Arc<Mutex<T>>` to get the async support you want, but `r2d2::Pool` will provide better ergonomics and save you some low-level synchronization boilerplate.

Personally, I like to use `sqlx` to talk to the database. I believe it has the best ergonomics in the ecosystem and they also use connection-pools, but it's API is exclusively asynchronous and it forces you to use async everywhere.